### PR TITLE
HTML5 Date Input Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var datePicker = new Ca11y(input, options)
 Pass an input element into a new instance of `Ca11y`, and optionally pass in props to override the following defaults:
 ```js
 {
-  replaceDateInput: false, // Disable Ca11y when input[type=date] is supported
+  preferNative: true, // skip Ca11y when input[type=date] is supported
   transitionDuration: 0,
   months: [
     { fullName: 'January'   , displayName: 'Jan' }  ,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An accessible, light-weight, dependency-free date picker `< 5kb` gzipped. Bring your own styles.
 
 ```
-npm install ca11y --save 
+npm install ca11y --save
 ```
 
 ## Usage
@@ -17,13 +17,14 @@ const datePicker = new Ca11y(input, options)
 
 **es5**
 ```js
-var Ca11y = require('ca11y') 
+var Ca11y = require('ca11y')
 var datePicker = new Ca11y(input, options)
 ```
 
 Pass an input element into a new instance of `Ca11y`, and optionally pass in props to override the following defaults:
 ```js
 {
+  replaceDateInput: false, // Disable Ca11y when input[type=date] is supported
   transitionDuration: 0,
   months: [
     { fullName: 'January'   , displayName: 'Jan' }  ,

--- a/example/index.html
+++ b/example/index.html
@@ -17,7 +17,7 @@
       <p class="page-description">A lightweight, accessible date-picker.</p>
       <div>
         <label for="date-input">Date</label>
-        <input type="text" id="date-input" placeholder="MM/DD/YYY" data-module="ca11y">
+        <input type="date" id="date-input" placeholder="MM/DD/YYY" data-module="ca11y">
       </div>
     </form>
     <script src="demo.js"></script>

--- a/src/ca11y/index.js
+++ b/src/ca11y/index.js
@@ -7,12 +7,33 @@ import template from './lib/template'
 
 class Ca11y {
   constructor(el, options = {}) {
-    Ca11y.pickers.push(this)
-    this.props = Object.assign({}, defaults, options, { id: Ca11y.pickers.length })
-    this.setInitialState()
-    this.setUI(el)
-    this.selectDay(this.state.day, false, true)
-    this.listen()
+    if (this.shouldConstruct(el, options)) {
+      Ca11y.pickers.push(this)
+      this.props = Object.assign({}, defaults, options, { id: Ca11y.pickers.length })
+      this.setInitialState()
+      this.setUI(el)
+      this.selectDay(this.state.day, false, true)
+      this.listen()
+    } else {
+      console && console.warn('Ca11y instance not created for element', el)
+    }
+  }
+
+  shouldConstruct(el, options) {
+    return options.replaceDateInput !== true && !this.isDateInput(el)
+  }
+
+  isDateInput(el) {
+    let input = document.createElement('input')
+    input.setAttribute('type', 'date')
+    let isDate = input.type !== 'text' && 'style' in input
+    let smile = '1)'
+    if (isDate) {
+      input.value = smile
+      input.style.cssText = 'position:absolute;visibility:hidden;'
+      isDate = input.value != smile
+    }
+    return isDate
   }
 
   setInitialState() {
@@ -200,6 +221,7 @@ class Ca11y {
   }
 
   setUI(el) {
+    el.setAttribute('type', 'text') // in case this is [type="date"]
     const calendarId = `ca11y-${ this.props.id }__picker`
 
     this.ui = {

--- a/src/ca11y/index.js
+++ b/src/ca11y/index.js
@@ -7,9 +7,10 @@ import template from './lib/template'
 
 class Ca11y {
   constructor(el, options = {}) {
-    if (this.shouldConstruct(el, options)) {
+    const props = Object.assign({}, defaults, options)
+    if (this.shouldConstruct(el, props)) {
       Ca11y.pickers.push(this)
-      this.props = Object.assign({}, defaults, options, { id: Ca11y.pickers.length })
+      this.props = Object.assign({}, props, { id: Ca11y.pickers.length })
       this.setInitialState()
       this.setUI(el)
       this.selectDay(this.state.day, false, true)
@@ -19,11 +20,11 @@ class Ca11y {
     }
   }
 
-  shouldConstruct(el, options) {
-    return options.replaceDateInput !== true && !this.isDateInput(el)
+  shouldConstruct(el, props) {
+    return props.preferNative === false || !this.isDateInputSupported(el)
   }
 
-  isDateInput(el) {
+  isDateInputSupported(el) {
     let input = document.createElement('input')
     input.setAttribute('type', 'date')
     let isDate = input.type !== 'text' && 'style' in input

--- a/src/ca11y/lib/defaults.js
+++ b/src/ca11y/lib/defaults.js
@@ -1,6 +1,6 @@
 export default {
-  // If animating open the picker, specify the transitionDuration
-  transitionDuration: 200,
+  replaceDateInput: false, // Disable Ca11y when input[type=date] is supported
+  transitionDuration: 200, // If animating open the picker, specify the transitionDuration
   months: [
     { fullName: 'January'   , displayName: 'Jan' } ,
     { fullName: 'February'  , displayName: 'Feb' } ,

--- a/src/ca11y/lib/defaults.js
+++ b/src/ca11y/lib/defaults.js
@@ -1,5 +1,5 @@
 export default {
-  replaceDateInput: false, // Disable Ca11y when input[type=date] is supported
+  preferNative: true, // skip Ca11y when input[type=date] is supported
   transitionDuration: 200, // If animating open the picker, specify the transitionDuration
   months: [
     { fullName: 'January'   , displayName: 'Jan' } ,

--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,6 @@
 <form>
   <div>
     <label for="date-input">Date</label>
-    <input type="text" id="date-input">
+    <input type="date" id="date-input">
   </div>
 </form>


### PR DESCRIPTION
Adds a `preferNative: true` default option and tests for native `input[type=date]` support before initializing Ca11y. Also updates the existing example and test HTML to use a date input instead of a text input.

Google Chrome example with default options, where Ca11y is disabled:

<img width="920" alt="screen shot 2016-01-11 at 12 22 59 pm" src="https://cloud.githubusercontent.com/assets/1019830/12241340/a713e0f0-b860-11e5-8cd9-e3532fecdb6a.png">

Relevant links:
http://caniuse.com/#feat=input-datetime
https://github.com/Modernizr/Modernizr/blob/695fd5ef3cad5b867785d5cff471d52a49aa82a7/feature-detects/inputtypes.js
