### PR TITLE
Parse and Formatting refactor

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -17,7 +17,7 @@
       <p class="page-description">A lightweight, accessible date-picker.</p>
       <div>
         <label for="date-input">Date</label>
-        <input type="text" id="date-input" placeholder="YYYY-MM-DD" data-module="ca11y">
+        <input type="date" id="date-input" placeholder="mm/dd/yyyy" data-module="ca11y">
       </div>
     </form>
     <script src="demo.js"></script>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "NODE_ENV=test karma start karma.config.js --single-run",
     "test-watch": "NODE_ENV=test karma start karma.config.js",
-    "deploy": "NODE_ENV=production  webpack src/ca11y/index.js example/demo.js -p && npm run sass && gh-pages -d example -b gh-pages",
+    "deploy": "NODE_ENV=production webpack src/demo.js example/demo.js -p && npm run sass && gh-pages -d example -b gh-pages",
     "start": "webpack src/demo.js example/demo.js & npm run sass && npm run watch",
     "sass": "node-sass src/demo.sass example/demo.css -i",
     "watch": "node-sass src/demo.sass example/demo.css -i -w & webpack src/demo.js example/demo.js --watch & browser-sync start --server example --files 'example/*, index.html'",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "prepublish": "NODE_ENV=production rm -rf dist && babel src/ca11y -d dist && webpack src/ca11y dist/ca11y.min.js -p --output-library-target var --output-library Ca11y"
   },
   "keywords": [
+    "a11y",
+    "accessible",
     "calendar",
-    "datepicker",
+    "callendar",
+    "cally",
     "date",
+    "datepicker",
     "picker",
-    "time",
-    "vanilla",
-    "js"
+    "vanilla"
   ],
   "author": "Dan Tello",
   "license": "MIT",
@@ -53,7 +55,6 @@
     "webpack": "1.12.9"
   },
   "dependencies": {
-    "delegate": "git://github.com/vigetlabs/delegate#3.0.1",
-    "fast-strftime": "1.1.1"
+    "delegate": "3.0.1"
   }
 }

--- a/src/ca11y/index.js
+++ b/src/ca11y/index.js
@@ -108,7 +108,7 @@ class Ca11y {
       fullYear          : date.getFullYear(),
       totalDays         : util.getDays(year, month),
       firstWeekdayValue : util.getFirstDay(year, month),
-      formats: {
+      parsed: {
         d: day,
         dd:  zeroPad(day),
         ddd: this.props.days[date.getDay(day)].shortName,
@@ -364,14 +364,18 @@ class Ca11y {
    * @return { Void }
    **/
   render(silent) {
-    this.ui.monthHeader.innerHTML    = this.renderMonthHeader()
-    this.ui.monthCaption.textContent = `${this.state.monthNameFull} ${this.state.fullYear}`
-    this.ui.calendarDays.innerHTML   = this.renderRows()
-    this.ui.selectedDay              = this.ui.calendar.querySelector('.ca11y__day.-selected')
+    const { input, monthHeader, monthCaption, calendarDays, selectedDay, calendar } = this.ui
+    const { parsed } = this.state
+    const { format, formatter, delimiter, date, onSelect } = this.props
+    const formattedValue = formatter(parsed, format, delimiter, date)
+
+    monthHeader.innerHTML    = this.renderMonthHeader()
+    monthCaption.textContent = `${this.state.monthNameFull} ${this.state.fullYear}`
+    calendarDays.innerHTML   = this.renderRows()
+    this.ui.selectedDay      = calendar.querySelector('.ca11y__day.-selected')
+
     // update the input to reflect new state
-    const state = this.state.formats
-    const { format, delimiter, date } = this.props
-    if(!silent) this.ui.input.value = this.props.formatter(state, format, delimiter, date)
+    if(!silent) onSelect(input, formattedValue, parsed, date)
   }
 }
 

--- a/src/ca11y/lib/defaults.js
+++ b/src/ca11y/lib/defaults.js
@@ -1,9 +1,11 @@
 import parser from './parse'
 import formatter from './format'
+import onSelect from './onSelect'
 
 export default {
   parser,
   formatter,
+  onSelect,
   format: ['mm', 'dd', 'yyyy'],
   delimiter: "/",
   transitionDuration: 200, // If animating open the picker, specify the transitionDuration

--- a/src/ca11y/lib/defaults.js
+++ b/src/ca11y/lib/defaults.js
@@ -1,33 +1,35 @@
-import parse from './parse'
-import format from './format'
+import parser from './parse'
+import formatter from './format'
 
 export default {
-  parse,
-  format,
-  // If animating open the picker, specify the transitionDuration
-  transitionDuration: 200,
+  parser,
+  formatter,
+  format: ['mm', 'dd', 'yyyy'],
+  delimiter: "/",
+  transitionDuration: 200, // If animating open the picker, specify the transitionDuration
+  autofill: false,
   months: [
-    { fullName: 'January'   , displayName: 'Jan' } ,
-    { fullName: 'February'  , displayName: 'Feb' } ,
-    { fullName: 'March'     , displayName: 'Mar' } ,
-    { fullName: 'April'     , displayName: 'Apr' } ,
-    { fullName: 'May'       , displayName: 'May' } ,
-    { fullName: 'June'      , displayName: 'Jun' } ,
-    { fullName: 'July'      , displayName: 'Jul' } ,
-    { fullName: 'August'    , displayName: 'Aug' } ,
-    { fullName: 'September' , displayName: 'Sep' } ,
-    { fullName: 'October'   , displayName: 'Oct' } ,
-    { fullName: 'November'  , displayName: 'Nov' } ,
-    { fullName: 'December'  , displayName: 'Dec' }
+    { fullName: 'January'   , displayName: 'Jan', shortName: 'Jan' } ,
+    { fullName: 'February'  , displayName: 'Feb', shortName: 'Feb' } ,
+    { fullName: 'March'     , displayName: 'Mar', shortName: 'Mar' } ,
+    { fullName: 'April'     , displayName: 'Apr', shortName: 'Apr' } ,
+    { fullName: 'May'       , displayName: 'May', shortName: 'May' } ,
+    { fullName: 'June'      , displayName: 'Jun', shortName: 'Jun' } ,
+    { fullName: 'July'      , displayName: 'Jul', shortName: 'Jul' } ,
+    { fullName: 'August'    , displayName: 'Aug', shortName: 'Aug' } ,
+    { fullName: 'September' , displayName: 'Sep', shortName: 'Sep' } ,
+    { fullName: 'October'   , displayName: 'Oct', shortName: 'Oct' } ,
+    { fullName: 'November'  , displayName: 'Nov', shortName: 'Nov' } ,
+    { fullName: 'December'  , displayName: 'Dec', shortName: 'Dec' }
   ],
   days: [
-    { fullName: 'Sunday'    , displayName: 'S' } ,
-    { fullName: 'Monday'    , displayName: 'M' } ,
-    { fullName: 'Tuesday'   , displayName: 'T' } ,
-    { fullName: 'Wednesday' , displayName: 'W' } ,
-    { fullName: 'Thursday'  , displayName: 'T' } ,
-    { fullName: 'Friday'    , displayName: 'F' } ,
-    { fullName: 'Saturday'  , displayName: 'S' }
+    { fullName: 'Sunday'    , displayName: 'S', shortName: 'Sun' } ,
+    { fullName: 'Monday'    , displayName: 'M', shortName: 'Mon' } ,
+    { fullName: 'Tuesday'   , displayName: 'T', shortName: 'Tue' } ,
+    { fullName: 'Wednesday' , displayName: 'W', shortName: 'Wed' } ,
+    { fullName: 'Thursday'  , displayName: 'T', shortName: 'Thu' } ,
+    { fullName: 'Friday'    , displayName: 'F', shortName: 'Fri' } ,
+    { fullName: 'Saturday'  , displayName: 'S', shortName: 'Sat' }
   ],
   dayTitles: [
     'First',
@@ -41,8 +43,8 @@ export default {
     'Ninth',
     'Tenth',
     'Eleventh',
-    'Twelth',
-    'Thirtheenth',
+    'Twelfth',
+    'Thirteenth',
     'Fourteenth',
     'Fifteenth',
     'Sixteenth',

--- a/src/ca11y/lib/format.js
+++ b/src/ca11y/lib/format.js
@@ -1,5 +1,5 @@
-import strftime from 'fast-strftime'
-
-export default function format(date) {
-  return strftime('%F', date)
+export default function format(state, format, delimiter, date) {
+  const chunks = format.map((format)=> state[format])
+  console.log(state)
+  return chunks.join(delimiter)
 }

--- a/src/ca11y/lib/format.js
+++ b/src/ca11y/lib/format.js
@@ -1,5 +1,3 @@
 export default function format(state, format, delimiter, date) {
-  const chunks = format.map((format)=> state[format])
-  console.log(state)
-  return chunks.join(delimiter)
+  return format.map((format)=> state[format]).join(delimiter)
 }

--- a/src/ca11y/lib/onSelect.js
+++ b/src/ca11y/lib/onSelect.js
@@ -1,0 +1,3 @@
+export default function onSelect(input, value, state, date) {
+  input.value = value
+}

--- a/src/ca11y/lib/parse.js
+++ b/src/ca11y/lib/parse.js
@@ -72,7 +72,11 @@ export default function parser(string, format, delimiter) {
 
   const { yyyy, mm, dd } = normalized
   const valid = yyyy && mm && dd
-  console.log(normalized)
-  const date = new Date(`${yyyy}-${mm}-${dd}`)
+
+  const date = new Date()
+  const offset = date.getTimezoneOffset() * 60 * 1000
+  const parsed = Date.parse(`${yyyy}-${mm}-${dd}`)
+  date.setTime(parsed + offset)
+
   return { date, valid }
 }

--- a/src/ca11y/lib/parse.js
+++ b/src/ca11y/lib/parse.js
@@ -1,16 +1,78 @@
-export default function parse(str) {
-  // implicit Date.parse( .. )
+import zeroPad from './zeroPad'
+
+export function inferCenturyFromTwoDigitYear(year) {
+  const thisYear = new Date().getFullYear()
+  const thisCentury = thisYear.toString().substring(0, 2)
+  const isTheFuture = Number(`${thisCentury}${year}`) > thisYear
+  return zeroPad(isTheFuture ? thisCentury - 1 : thisCentury)
+}
+
+export function parseChunk(format, value) {
   const date = new Date()
+  let dayStub = 1
+  let month = 1
+  let yearStub = 2000
+  let timestamp = null
 
-  // correct for local time
-  const offset = date.getTimezoneOffset() * 60 * 1000
+  switch (format) {
+    case 'd':
+      return {
+        type: 'dd',
+        value: zeroPad(value)
+      }
+    case 'dd':
+      return {
+        type: 'dd',
+        value: value
+      }
+    case 'm':
+      return {
+        type: 'mm',
+        value: zeroPad(value)
+      }
+    case 'mm':
+      return {
+        type: 'mm',
+        value: value
+      }
+    case 'mmm':
+      timestamp = Date.parse(`${dayStub} ${value} ${yearStub}`)
+      return {
+        type: 'mm',
+        value: zeroPad(new Date(timestamp).getMonth())
+      }
+    case 'mmmm':
+      timestamp = Date.parse(`${dayStub} ${value} ${yearStub}`)
+      return {
+        type: 'mm',
+        value: zeroPad(new Date(timestamp).getMonth())
+      }
+    case 'yy':
+      return {
+        type: 'yyyy',
+        value: `${inferCenturyFromTwoDigitYear(value)}${value}`
+      }
+    case 'yyyy':
+      return {
+        type: 'yyyy',
+        value: value
+      }
+  }
+}
 
-  // returns NaN or number (epoch offset)
-  const parsed = Date.parse(str)
-  const valid  = !isNaN(parsed)
+export default function parser(string, format, delimiter) {
+  const dateArray = string.split(delimiter)
 
-  // if the date is valid, add the offset and save the value
-  if (valid) date.setTime(parsed + offset)
+  const normalized = format.reduce(function(formats, format, i) {
+    const value = dateArray[i]
+    const parsed = parseChunk(format, value)
+    formats[parsed.type] = parsed.value
+    return formats
+  }, {})
 
+  const { yyyy, mm, dd } = normalized
+  const valid = yyyy && mm && dd
+  console.log(normalized)
+  const date = new Date(`${yyyy}-${mm}-${dd}`)
   return { date, valid }
 }

--- a/src/ca11y/lib/zeroPad.js
+++ b/src/ca11y/lib/zeroPad.js
@@ -1,3 +1,3 @@
 export default function zeroPad(number) {
-  return ("0" + number).slice(-2)
+  return ("0" + Number(number)).slice(-2)
 }

--- a/src/demo/_theme.sass
+++ b/src/demo/_theme.sass
@@ -58,7 +58,7 @@
   background-color: $grey-90
   border-radius: 100px
   border: none
-  bottom: 14px
+  bottom: 12px
   color: inherit
   display: block
   font-weight: bold
@@ -95,6 +95,7 @@
   font-size: 11px
   font-weight: bold
   margin-top: 16px
+  min-height: 240px
   overflow: hidden
   padding: 8px 8px 8px 90px
   position: absolute


### PR DESCRIPTION
**Updated Demo: http://code.viget.com/ca11y/**

This addresses comments in #32, and adds some easy lightweight parsing and formatting out of the box. 
- Replace strftime with simple string interpolation
- Rename "format" and "parse" to "formatter" and "parser"
- add "format" option. E.g., `['mm', 'dd', 'yyyy']`
- add "delimiter" option for use with "format". e.g., '/'

You can still provide custom `parser` and `formatter` props, but now, just providing a `format` and `delimiter` should cover most use cases.

``` js
Ca11y.init('[data-module="ca11y"]', {
  format: ['mm', 'dd', 'yyyy'],
  delimiter: '-'
})
```

After this gets merged, we should do a code freeze and just write tests and fix any bugs that come up.
Need to update the README as well if this approach looks good.

Resolves #33 
Resolves #31 
Resolves #28 
Resolves #25 (just default to today if invalid input value)
Resolves #22
Resolves #20
Resolves #6
