### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.0.0
+- Adds `options.container` to ouput datepicker to a specific markup location
+- Adds `options.toggle` (different than previously named `options.toggle`) to use an existing element as the datepicker toggle
+- Moves `options.toggle.button` to `options.toggleIcon`
+- Moves `options.toggle.label` to `options.toggleAriaLabel`
+- Resolves #43
+- Resoves #44

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Set to `true` if you want a blank input to be auto-filled with today's date.
 #### `options.onSelect`
 ```js
 const datePicker = new Ca11y(input, {
-  onSelect: onSelect(input, value, state, date) {
+  onSelect: onSelect(value, input, state, date) {
     input.value = value
   }  // default
 })

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ Pass any of the [options listed below](#options) to override [the defaults](http
 
 ## Options
 ### Basic
+#### `options.container`
+```js
+const datePicker = new Ca11y(input, {
+  container: input.parentElement // default
+})
+```
+The HTML element where you want the datepicker to render. 
+
+#### `options.toggle`
+```js
+const datePicker = new Ca11y(input, {
+  toggle: this.ui.datePicker.querySelector('.ca11y__toggle') // default (dynaically created)
+})
+```
+The HTML element that should toggle datepicker when clicked. Defaults to a dynamically created button. 
+
+
 #### `options.format`
 ```js
 const datePicker = new Ca11y(input, {
@@ -156,17 +173,23 @@ dayTitles: [
 Read aloud by screen readers when a date receives focus. Override with other languages or desired text.
 
 #### UI
-#### `options.toggle`
+#### `options.toggleIcon`
 ```js
 const datePicker = new Ca11y(input, {
-  toggle: {
-    html: '<button>Toggle me!</button>',
-    label: 'Toggle Date Picker'
-  }
+  toggleIcon: "<svg>...</svg>" // defaults to Google material calendar icon
 })
 ```
 
-The `html` will be rendered as the toggle button next to the input. The `label` is screen-reader only. Defaults to `svg` iconography from https://design.google.com/icons/.
+The icon to be rendered as the toggle button label. Defaults to `svg` iconography from https://design.google.com/icons/.
+
+#### `options.toggleAriaLabel`
+```js
+const datePicker = new Ca11y(input, {
+  toggleAriaLabel: "Toggle the Datepicker" // default
+})
+```
+
+The `aria-label` that should be read by a screen reader when the (default) toggle button is focused.
 
 #### `options.next`
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca11y",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "A lightweight accessible datepicker",
   "homepage": "http://code.viget.com/ca11y/",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ca11y",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A lightweight accessible datepicker",
   "homepage": "http://code.viget.com/ca11y/",
   "main": "dist/index.js",

--- a/src/ca11y/index.js
+++ b/src/ca11y/index.js
@@ -381,7 +381,7 @@ class Ca11y {
     this.ui.selectedDay      = calendar.querySelector('.ca11y__day.-selected')
 
     // update the input to reflect new state
-    if(!silent) onSelect(input, formattedValue, parsed, date)
+    if(!silent) onSelect(formattedValue, input, parsed, date)
   }
 }
 

--- a/src/ca11y/index.js
+++ b/src/ca11y/index.js
@@ -62,7 +62,7 @@ class Ca11y {
 
     this.ui = {
       input      : input,
-      wrapper    : input.parentElement,
+      wrapper    : this.props.container || input.parentElement,
       datePicker : document.createElement('div')
     }
 
@@ -80,7 +80,7 @@ class Ca11y {
     this.ui.calendarDays = this.ui.datePicker.querySelector('.ca11y__days')
     this.ui.monthCaption = this.ui.datePicker.querySelector('.ca11y__caption')
     this.ui.monthHeader  = this.ui.datePicker.querySelector('.ca11y__header')
-    this.ui.toggle       = this.ui.datePicker.querySelector('.ca11y__toggle')
+    this.ui.toggle       = this.props.toggle || this.ui.datePicker.querySelector('.ca11y__toggle')
     this.ui.picker       = this.ui.datePicker.querySelector('.ca11y__picker')
     this.ui.wrapper.appendChild(this.ui.datePicker)
 
@@ -95,6 +95,9 @@ class Ca11y {
    * @return { Void }
    **/
   setDate(date, silent=false) {
+
+    if(date.toString() === "Invalid Date") return
+
     const month     = date.getMonth()
     const day       = date.getDate()
     const year      = date.getFullYear()

--- a/src/ca11y/lib/defaults.js
+++ b/src/ca11y/lib/defaults.js
@@ -66,10 +66,8 @@ export default {
     'Thirtieth',
     'Thirty First'
   ],
-  toggle: {
-    html: '<svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/></svg>',
-    label: 'Toggle Date Picker'
-  },
+  toggleAriaLabel: 'Toggle Date Picker',
+  toggleIcon: '<svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"/></svg>',
   next: {
     html: '<svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"/></svg>',
     label: 'Next Month'

--- a/src/ca11y/lib/template.js
+++ b/src/ca11y/lib/template.js
@@ -49,17 +49,22 @@ const TEMPLATES = {
   },
 
   calendar(data) {
-    return `
+    const defaultButton = `
       <button
         type="button"
         class="ca11y__toggle"
         aria-label="Toggle Date Picker"
         aria-controls="${ data.calendarId }"
-        aria-label="${ data.toggle.label }"
+        aria-label="${ data.toggleAriaLabel }"
       >
-        ${ data.toggle.html }
+        ${ data.toggleIcon }
       </button>
+    `
 
+    const button = data.toggle ? '' : defaultButton
+
+    return `
+      ${ button }
       <div
         role="dialog"
         id="${ data.calendarId }"

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,8 +1,6 @@
 import Ca11y from './ca11y'
 
 Ca11y.init('[data-module="ca11y"]', {
-  container: document.querySelector('.picker-container'),
-  toggle: document.querySelector('.picker-toggle'),
   format: ['yyyy', 'mm', 'dd'],
   delimiter: '-'
 })

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,6 +1,8 @@
 import Ca11y from './ca11y'
 
 Ca11y.init('[data-module="ca11y"]', {
+  container: document.querySelector('.picker-container'),
+  toggle: document.querySelector('.picker-toggle'),
   format: ['yyyy', 'mm', 'dd'],
   delimiter: '-'
 })


### PR DESCRIPTION
#1.0.0
- Adds options.container to ouput datepicker to a specific markup location
- Adds options.toggle (different than previously named options.toggle) to use an existing element as the datepicker toggle
- Moves options.toggle.button to options.toggleIcon
- Moves options.toggle.label to options.toggleAriaLabel
- Fix invalid date bug (#43)
- Change onSuccess param order (#44) so value is first
